### PR TITLE
Revert automatic pwa updates to prompt

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -178,8 +178,8 @@ const config: UserConfig = defineConfig({
           'node_modules/**/*',
           'dev-dist/**'
         ],
-        clientsClaim: true,
-        skipWaiting: true,
+        clientsClaim: false,
+        skipWaiting: false,
         // Handle SvelteKit's routing
         navigateFallback: '/',
         navigateFallbackDenylist: [/^\/_app\//, /^\/api\//],


### PR DESCRIPTION
Disable automatic PWA updates to revert to prompt-based updates.

---
[Slack Thread](https://stevenharrisdev.slack.com/archives/C09CA4M91QF/p1756487854946879?thread_ts=1756487854.946879&cid=C09CA4M91QF)

<a href="https://cursor.com/background-agent?bcId=bc-c3699bdf-7338-4dc1-9f4f-33260f1c5750">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c3699bdf-7338-4dc1-9f4f-33260f1c5750">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

