### PR TITLE
Potential fix for code scanning alert no. 132: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,4 +1,6 @@
 name: 🔍 Pull Request
+permissions:
+  contents: read
 on:
   pull_request:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/Steven-Harris/githelm/security/code-scanning/132](https://github.com/Steven-Harris/githelm/security/code-scanning/132)

To address this issue, add a `permissions` block to the root of the workflow file (`.github/workflows/pull-request.yml`), before the `jobs:` key. This will apply least-privilege permissions for all jobs, unless overridden per-job. The best starting point is `contents: read`, which suffices for most testing, building, and deployment actions that merely read repository data. If any action needs further permissions (e.g., creating pull request comments or reporting statuses), those can be incrementally added. Based on the file, the minimal base permission is `contents: read`. If you discover specific steps (such as uploading artifacts) or commenting on pull requests, you can add e.g. `pull-requests: write`, but this workflow does not include such steps natively.

Make a single edit: Add the following block after the `name:` key, at the top of `.github/workflows/pull-request.yml`:
```yaml
permissions:
  contents: read
```
No additional imports or changes are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
